### PR TITLE
fix: restore custom url servers

### DIFF
--- a/kintone/20250101000000/openapi.yaml
+++ b/kintone/20250101000000/openapi.yaml
@@ -3,7 +3,16 @@ openapi: "3.1.0"
 info:
   title: "REST API SPEC"
   version: "20250101000000"
-servers: []
+servers:
+  #  - url: https://sample.cybozu.com
+  - url: https://{domainId}.cybozu.com
+    variables:
+      domainId:
+        default: sample
+  - url: "{Custom URL}"
+    variables:
+      "Custom URL":
+        default: https://sample.cybozu.com
 paths:
   /k/guest/{guestSpaceId}/v1/app.json:
     $ref: "./paths/k_guest_v1_app.yaml"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Swagger UIでは任意のサブドメインを受け付けるようにしていた（https://github.com/kintone/rest-api-spec/pull/5 ）が、openapi.yamlの更新時（https://github.com/kintone/rest-api-spec/pull/6 ）にその設定が消えてしまっていた。

## What

<!-- What is a solution you want to add? -->

- serversの設定を復元した

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read CONTRIBUTING.md at the repository.
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
