### PR TITLE
fix: add base to vite.config.js

### DIFF
--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -13,6 +13,7 @@ const files = (
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: "/rest-api-spec/",
   define: {
     "import.meta.env.OAS_ENTRY_FILE_PATHS":
       files satisfies ImportMetaEnv["OAS_ENTRY_FILE_PATHS"],


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

- /xxx.css and /yyy.js paths are absolute, so they point to https://kintone.github.io/xxx.css
- But the GitHub Pages is hosted under https://kintone.github.io/rest-api-spec/

## What

<!-- What is a solution you want to add? -->

Set base in vite.config.ts

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read CONTRIBUTING.md at the repository.
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
