### PR TITLE
chore: add Takumi Guard npm security scanning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install --fetch-timeout 900000 --frozen-lockfile
       - run: pnpm bundle
       - run: git diff --stat --exit-code
@@ -50,7 +50,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install
       - run: pnpm lint
 
@@ -69,6 +69,6 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install
       - run: pnpm doc:build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --fetch-timeout 900000 --frozen-lockfile
@@ -48,7 +48,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install
@@ -67,7 +67,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,9 @@ jobs:
   bundle:
     name: Check that all bundled yaml files are updated
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
@@ -25,6 +28,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install --fetch-timeout 900000 --frozen-lockfile
       - run: pnpm bundle
       - run: git diff --stat --exit-code
@@ -32,6 +38,9 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
@@ -39,12 +48,18 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install
       - run: pnpm lint
 
   pages:
     name: Check website build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
@@ -52,5 +67,8 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install
       - run: pnpm doc:build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
           bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install --fetch-timeout 900000 --frozen-lockfile
       - run: pnpm bundle
+      - run: git checkout -- .npmrc 2>/dev/null || true
       - run: git diff --stat --exit-code
 
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,14 @@ jobs:
   validate:
     name: Validate yaml files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: flatt-security/setup-takumi-guard-pypi@7d825811bb293b9e0230477165442580a0074280 # v1.0.0
+        with:
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pip install openapi-spec-validator
       - run: find ./kintone -name "openapi.yaml" -type f | xargs openapi-spec-validator
 

--- a/.github/workflows/swagger.yaml
+++ b/.github/workflows/swagger.yaml
@@ -27,6 +27,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install
       - run: pnpm doc:build
       - name: Setup Pages Configuration

--- a/.github/workflows/swagger.yaml
+++ b/.github/workflows/swagger.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
       - run: pnpm install

--- a/.github/workflows/swagger.yaml
+++ b/.github/workflows/swagger.yaml
@@ -29,7 +29,7 @@ jobs:
           cache: "pnpm"
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - run: pnpm install
       - run: pnpm doc:build
       - name: Setup Pages Configuration


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

The CI pipelines did not perform any security scanning of npm/PyPI packages, leaving them vulnerable to supply chain attacks through malicious packages. By introducing Takumi Guard, we can detect malicious packages during `pnpm install` and `pip install`.

## What

- Added `flatt-security/setup-takumi-guard-npm` (SHA-pinned, v1.1.1) to `bundle`, `lint`, `pages` jobs in `ci.yaml` and `deploy` job in `swagger.yaml`
- Added `flatt-security/setup-takumi-guard-pypi` (SHA-pinned, v1.0.0) to `validate` job in `ci.yaml` for `pip install openapi-spec-validator`
- Added `permissions` (`contents: read`, `id-token: write`) to each job for OIDC authentication
- Fork PRs fall back to anonymous mode (empty bot-id) since secrets are not available
- Added `git checkout -- .npmrc` before `git diff --exit-code` in the `bundle` job to avoid false positives from Takumi Guard's `.npmrc` modifications

## How to test

- [ ] Verify that CI workflows run successfully
- [ ] Confirm Takumi Guard setup step completes without errors
- [ ] Ensure the `TAKUMI_GUARD_BOT_ID` secret is configured in the repository

## Checklist

- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.